### PR TITLE
Don't try to save a file that doesn't yet exists

### DIFF
--- a/auto_save.py
+++ b/auto_save.py
@@ -18,7 +18,7 @@ class AutoSaveListener(sublime_plugin.EventListener):
   def on_modified(self, view):
     settings = sublime.load_settings(auto_save_settings_filename)
 
-    if settings.get("auto_save_on_modified"):
+    if settings.get("auto_save_on_modified") and view.file_name():
       view.run_command("save")
 
 


### PR DESCRIPTION
This prevents a save dialog from popping up on every keystroke of a new file. You probably don't want to auto save a file that doesn't exist anyways.
