### PR TITLE
Sublime Text 2 compatibility Fix: Must call on main thread, consider using sublime.set_timeout(function, timeout)

### DIFF
--- a/auto_save.py
+++ b/auto_save.py
@@ -23,7 +23,9 @@ class AutoSaveListener(sublime_plugin.EventListener):
   def on_modified(self, view):
     settings = sublime.load_settings(settings_filename)
     delay = settings.get(delay_field)
-
+    
+    def callback():
+      view.run_command("save")
 
     '''
     If the queue is longer than 1, pop the last item off,
@@ -33,7 +35,8 @@ class AutoSaveListener(sublime_plugin.EventListener):
       if len(AutoSaveListener.save_queue) > 1:
         AutoSaveListener.save_queue.pop()
       else:
-        view.run_command("save")
+        # view.run_command("save")
+        sublime.set_timeout(callback, 0)
         AutoSaveListener.save_queue = []
 
 


### PR DESCRIPTION
Fix for:
Exception in thread Thread-95:
Traceback (most recent call last):
  File ".\threading.py", line 532, in __bootstrap_inner
  File ".\threading.py", line 736, in run
  File ".\auto_save.py", line 37, in debounce_save
    if len(AutoSaveListener.save_queue) > 1:
RuntimeError: Must call on main thread, consider using sublime.set_timeout(function, timeout)
