### PR TITLE
Check is_dirty to prevent invoking auto-save when file is reloaded from disk

### DIFF
--- a/auto_save.py
+++ b/auto_save.py
@@ -29,7 +29,11 @@ class AutoSaveListener(sublime_plugin.EventListener):
     Must use this callback for ST2 compatibility
     '''
     def callback():
-      view.run_command("save")
+      if view.is_dirty() and not view.is_loading():
+          view.run_command("save")
+      else:
+        print("Auto-save callback invoked, but view is",
+              "currently loading." if view.is_loading() else "unchanged from disk.")
 
 
     '''
@@ -44,7 +48,7 @@ class AutoSaveListener(sublime_plugin.EventListener):
         AutoSaveListener.save_queue = []
 
 
-    if settings.get(on_modified_field) and view.file_name():
+    if settings.get(on_modified_field) and view.file_name() and view.is_dirty():
       AutoSaveListener.save_queue.append(0) # Append to queue for every on_modified event.
       Timer(delay, debounce_save).start() # Debounce save by the specified delay.
 


### PR DESCRIPTION
Hi James,
First, thank you for this wonderful ST plug-in. I use it pretty much every day when taking notes at work to make sure all changes are saved.

I noticed an issue caused by auto-save's callback being called when the file is reloaded from disk. In my case, this happens if I change the file on another computer and the file is then synced via Dropbox. But it can also happen if a local program is appending the file while it is open in Sublime Text (and auto-save is active). What happens is that when a file is changed on disk, Sublime Text will automatically reload it. When reloading a file, Sublime Text will call EventListeners' on_modified. (It actually calls it twice, although that might be a bug.)

Calling EventListeners' on_modified may be desired for other plugins. However, we do not want auto-save to save the view after the file has been reloaded. First, because the file is already in sync with the disk (since it has just been reloaded). And second, because if another program is actively updating a file, and Sublime Text then also tries to save the file every time it is reloaded, this can produce conflicting versions.

The issues can be resolved by checking whether the view actually needs to be saved using view.is_dirty(). I've also added a check for view.is_loading(), which becomes relevant for very large files (larger than 5-10 MB on my system).

I've placed the is_dirty() check both in the callback() function and in the EventListener's on_modified() method. The check in the callback() function is the most important. However, as mentioned, on_modified is called twice when a file is reloaded (at least in the current version of Sublime). The first time on_modified() is called, is_dirty() returns True. The second time, is_dirty() returns False. Checking is_dirty() before scheduling  debounce_save simply prevents the second of these two calls (i.e. it is just an optimization). Once the callback is called, view.is_dirty() will return False (at least in all my tests).
