### PR TITLE
Move check determining if auto save should fire to the top of on_modified

### DIFF
--- a/auto_save.py
+++ b/auto_save.py
@@ -22,6 +22,9 @@ class AutoSaveListener(sublime_plugin.EventListener):
 
   def on_modified(self, view):
     settings = sublime.load_settings(settings_filename)
+    if not (settings.get(on_modified_field) and view.file_name() and view.is_dirty()):
+      return
+
     delay = settings.get(delay_field)
 
 
@@ -48,9 +51,8 @@ class AutoSaveListener(sublime_plugin.EventListener):
         AutoSaveListener.save_queue = []
 
 
-    if settings.get(on_modified_field) and view.file_name() and view.is_dirty():
-      AutoSaveListener.save_queue.append(0) # Append to queue for every on_modified event.
-      Timer(delay, debounce_save).start() # Debounce save by the specified delay.
+    AutoSaveListener.save_queue.append(0) # Append to queue for every on_modified event.
+    Timer(delay, debounce_save).start() # Debounce save by the specified delay.
 
 
 class AutoSaveCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
I suggest we move the check that determines if auto save should fire to the top of on_modified. 
Right now we are querying settings and defining callback and debounce_save and then finally we check whether we actually need to use these. There is no need to repeatedly define callback and debounce_save if they are never used.
Moving the check to the top of the method makes it a little more clear that if any of the given criteria are not met, on_modified will return without doing anything.