### PR TITLE
AutoSaveCommand should be an ApplicationCommand.

### DIFF
--- a/auto_save.py
+++ b/auto_save.py
@@ -55,9 +55,9 @@ class AutoSaveListener(sublime_plugin.EventListener):
     Timer(delay, debounce_save).start() # Debounce save by the specified delay.
 
 
-class AutoSaveCommand(sublime_plugin.TextCommand):
+class AutoSaveCommand(sublime_plugin.ApplicationCommand):
 
-  def run(self, view, enable=None):
+  def run(self, enable=None):
     '''
     Toggle auto-save on and off. Can be bound to a keystroke, e.g. ctrl+alt+s.
     If enable argument is given, auto save will be enabled (if True) or disabled (if False).


### PR DESCRIPTION
I suggest we change AutoSaveCommand to derive from ApplicationCommand instead of TextCommand. TextCommands are usually used to manipulate text or otherwise work on the current view/buffer. AutoSaveCommand works globally, turning auto-save on/off for all views in all windows.  
 (https://www.sublimetext.com/docs/3/api_reference.html#sublime_plugin.ApplicationCommand)
And thank you for accepting my previous PRs! :)