### PR TITLE
Add useful options to auto-save plugin (for example, auto-save only one file)

### DIFF
--- a/Main.sublime-commands
+++ b/Main.sublime-commands
@@ -1,0 +1,5 @@
+[
+  { "caption": "Toggle AutoSave: all files", "command": "auto_save" },
+  { "caption": "Toggle AutoSave: current file only", "command": "auto_save", "args": {"all_files": false} },
+  { "caption": "Toggle AutoSave Backup: current file only", "command": "auto_save", "args": {"all_files": false, "backup": true} }
+]

--- a/README.md
+++ b/README.md
@@ -37,13 +37,28 @@ git clone https://github.com/jamesfzhang/auto-save.git
 
 Usage
 -------
-**By default, auto-save is disabled** because it is a fairly invasive plugin.
-To enable it, you must first bind the command to turn the plugin
-on or off. Open "Preferences / Key Bindings - User" and add:
+**By default, auto-save is disabled** because it is a fairly invasive plugin. To make it less invasive, you can instruct it to only auto-save changes to the file that is active when you turn on auto-save. In this mode, it will ignore changes to all other files.
+
+You can also instruct it to auto-backup the file instead of auto-saving it. The backup gets created in the same directory as its source file. The backup file takes the same name as its source file, with the string `.autosave` inserted directly before the file extension.
+
+There are two ways to enable it. You can press <kbd>Command + Shift + P</kbd> to bring up the Command Palette, and search for **AutoSave**. Here, there are 3 options:
+
+- Toggle AutoSave: all files
+- Toggle AutoSave: current file only
+- Toggle AutoSave Backup: current file only
+
+Alternatively, you can bind commands to turn the plugin or off. For example, to toggle auto-save for all files, open "Preferences / Key Bindings - User" and add:
 
 ```js
 { "keys": ["ctrl+shift+s"], "command": "auto_save" }
 ```
+
+To toggle it for only the current file, and instruct to make a backup of the file instead of saving the file itself, you could add:
+
+```js
+{ "keys": ["ctrl+shift+s"], "command": "auto_save", "args": {"all_files": false, "backup": true} }
+```
+
 This key bindings file takes an array of key bindings so please ensure that this key binding, along with any existing ones, are properly wrapped in `[]`.
 
 With this setting, pressing <kbd>Ctrl + Shift + S</kbd> will turn the plugin

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There are two ways to enable it. You can press <kbd>Command + Shift + P</kbd> to
 - Toggle AutoSave: current file only
 - Toggle AutoSave Backup: current file only
 
-Alternatively, you can bind commands to turn the plugin or off. For example, to toggle auto-save for all files, open "Preferences / Key Bindings - User" and add:
+Alternatively, you can bind commands to turn the plugin on or off. For example, to toggle auto-save for all files, open "Preferences / Key Bindings - User" and add:
 
 ```js
 { "keys": ["ctrl+shift+s"], "command": "auto_save" }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage
 -------
 **By default, auto-save is disabled** because it is a fairly invasive plugin. To make it less invasive, you can instruct it to only auto-save changes to the file that is active when you turn on auto-save. In this mode, it will ignore changes to all other files.
 
-You can also instruct it to auto-backup the file instead of auto-saving it. The backup gets created in the same directory as its source file. The backup file takes the same name as its source file, with the string `.autosave` inserted directly before the file extension.
+You can also instruct it to auto-backup the file instead of auto-saving it. The backup gets created in the same directory as its source file. The backup file takes the same name as its source file, with the string `.autosave` inserted directly before the file extension. When auto-save is disabled, the backup file is deleted.
 
 There are two ways to enable it. You can press <kbd>Command + Shift + P</kbd> to bring up the Command Palette, and search for **AutoSave**. Here, there are 3 options:
 

--- a/auto_save.py
+++ b/auto_save.py
@@ -20,6 +20,8 @@ current_file_field = "auto_save_current_file"
 backup_field = "auto_save_backup"
 backup_suffix_field = "auto_save_backup_suffix"
 
+
+
 class AutoSaveListener(sublime_plugin.EventListener):
 
   save_queue = [] # Save queue for on_modified events.
@@ -59,9 +61,14 @@ class AutoSaveListener(sublime_plugin.EventListener):
           view.run_command("save")
         else: # Save backup file
           content = view.substr(sublime.Region(0, view.size()))
-          with open(AutoSaveListener.generate_backup_filename(
-            view.file_name(), backup_suffix), 'w') as f:
-            f.write(content)
+          try:
+            with open(AutoSaveListener.generate_backup_filename(
+              view.file_name(), backup_suffix), 'w', encoding='utf-8') as f:
+              f.write(content)
+          except Exception as e:
+            sublime.status_message(e)
+            raise e
+
       else:
         print("Auto-save callback invoked, but view is",
               "currently loading." if view.is_loading() else "unchanged from disk.")

--- a/auto_save.sublime-settings
+++ b/auto_save.sublime-settings
@@ -2,5 +2,9 @@
 
 {
   "auto_save_on_modified": false,
-  "auto_save_delay_in_seconds": 1
+  "auto_save_delay_in_seconds": 1,
+  "auto_save_all_files": true,
+  "auto_save_current_file": "",
+  "auto_save_backup": false,
+  "auto_save_backup_suffix": "autosave"
 }


### PR DESCRIPTION
Hey James, **auto-save** rocks! I'm using it to edit Markdown files in Sublime, which get saved on every change, transformed to html, and then refreshed in the browser by Gulp. It's truly sweet, and auto-save made it very easy to set up.

I added some functions to the plugin that I think are useful, and added information about these changes to the README:
- To make it less invasive, you can instruct it to only auto-save changes to the view that is active when you turn on auto-save. In this mode, it will ignore changes to all other files.
- You can also instruct it to auto-backup the file instead of auto-saving it. The backup gets created in the same directory as its source file. The backup file takes the same name as its source file, with the string .autosave inserted directly before the file extension, or at the end of the file if it has no extension. When auto-save is disabled, the backup file is deleted.

Also, I added a `Main.sublime-commands` file to allow users to disable and enable the plugin using the ST command palette in case they don't want to add a key binding. This is also in the README.

The way the arguments are parsed in `auto_save.py` means that the default mode of operation is unchanged, i.e. it still auto-saves all files when toggled, and the key bindings for this default mode of operation are likewise unchanged.

If you think these added options will make the plugin more versatile for users please pull them into your project!

In any case, please let me know what you think, and thanks for the plugin.