### PR TITLE
Add settings field 'save_when_autocompleting' that disables said behaviour when set to 'false'.

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -5,5 +5,6 @@
   "1.0.3": "messages/1.0.3.txt",
   "1.0.4": "messages/1.0.4.txt",
   "1.0.5": "messages/1.0.5.txt",
-  "1.0.6": "messages/1.0.6.txt"
+  "1.0.6": "messages/1.0.6.txt",
+  "1.0.7": "messages/1.0.7.txt"
 }

--- a/messages/1.0.7.txt
+++ b/messages/1.0.7.txt
@@ -1,0 +1,6 @@
+Improvements:
+
+* Add option for enabling this plugin for only current file
+* Add option for enabling "auto backup"
+
+See [this pull request](https://github.com/jamesfzhang/auto-save/pull/26) for more information. Thanks [kylebebak](https://github.com/kylebebak)!


### PR DESCRIPTION
- User can disable this behavior by adding '"save_when_autocompleting": true' to their user settings.
- If this setting is set to false, the plugin won't auto-save while the auto-complete dialog is open.
- If an on_modified event is triggered while the auto-complete dialog is open(by typing a character for example) the save will be delayed untill the dialog closes.

I have been testing this for a few days now without problems.

The setting can also be removed, if it's not likely that people will want their file to be saved when the dialog is open(thus closing the dialog).