### PR TITLE
Added support for auto-saving only specified file types

### DIFF
--- a/auto_save.py
+++ b/auto_save.py
@@ -18,6 +18,7 @@ delay_field = "auto_save_delay_in_seconds"
 all_files_field = "auto_save_all_files"
 current_file_field = "auto_save_current_file"
 ignore_files_field = "auto_save_ignore_files"
+only_files_field = "auto_save_only_files"
 backup_field = "auto_save_backup"
 backup_suffix_field = "auto_save_backup_suffix"
 
@@ -50,6 +51,10 @@ class AutoSaveListener(sublime_plugin.EventListener):
     for path in settings.get(ignore_files_field):
       if filename.endswith(path):
         return
+
+    only_files = settings.get(only_files_field, [])
+    if only_files and not any(filename.lower().endswith(extension.lower()) for extension in only_files):
+      return
 
     if not settings.get(all_files_field) and settings.get(current_file_field) != filename:
       return

--- a/auto_save.sublime-settings
+++ b/auto_save.sublime-settings
@@ -6,6 +6,7 @@
   "auto_save_all_files": true,
   "auto_save_current_file": "",
   "auto_save_ignore_files": [],
+  "auto_save_only_files": [],
   "auto_save_backup": false,
   "auto_save_backup_suffix": "autosave"
 }


### PR DESCRIPTION
This PR introduces a new optional setting that allows users to define an allowlist of file extensions for auto-save.

## ⚙️ Example configuration

```json
"auto_save_only_files": [".todo"]
```

When configured, auto-save will only apply to files matching the specified extensions.

Extension matching is case-insensitive, so `.TODO`, `.Todo`, and `.todo` are treated the same.

## ✅ Backward compatibility

When the list is empty, the plugin keeps its current behavior and auto-saves all eligible files.

This makes the change fully backward-compatible with existing configurations.

## ⚠️ Important note

The existing `auto_save_ignore_files` setting still takes precedence.

Therefore, if a file matches both `auto_save_only_files` and `auto_save_ignore_files`, it will not be auto-saved.

This addition provides more control over which file types are automatically saved without requiring users to maintain a large ignore list.
